### PR TITLE
Chore/bump blinks core

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ React Native SDK for rendering blinks for Solana Actions on mobile dApps. Check 
 ## Installation
 
 ```console
-# npm 
-npm i @dialectlabs/blinks @dialectlabs/blinks-react-native
+# npm
+npm i @dialectlabs/blinks-react-native
 
 #yarn
-yarn add @dialectlabs/blinks @dialectlabs/blinks-react-native
+yarn add @dialectlabs/blinks-react-native
 ```
 
 ## Adding the Blink Component
@@ -68,7 +68,7 @@ An [example](/example/src/Example.tsx) of this is:
       url: string; // could be action api or website url
     }> = ({ url }) => {
       const adapter = getWalletAdapter();
-      const { action } = useAction({ url, adapter });
+      const { action } = useAction({ url });
 
       if (!action) {
         // return placeholder component
@@ -81,6 +81,7 @@ An [example](/example/src/Example.tsx) of this is:
               '--blink-border-radius-rounded-button': 9999,
               // and any other custom styles
           }}
+          adapter={adapter}
           action={action}
           websiteUrl={actionUrl.href}
           websiteText={actionUrl.hostname}

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -40,7 +40,7 @@ export const BlinkExample: React.FC<{
   url: string; // could be action api or website url
 }> = ({ url }) => {
   const adapter = getWalletAdapter();
-  const { action } = useAction({ url, adapter });
+  const { action } = useAction({ url });
 
   if (!action) {
     return <ActivityIndicator />;
@@ -53,6 +53,7 @@ export const BlinkExample: React.FC<{
         '--blink-border-radius-rounded-button': 9999,
       }}
       action={action}
+      adapter={adapter}
       websiteUrl={actionUrl.href}
       websiteText={actionUrl.hostname}
     />
@@ -63,7 +64,7 @@ export const MiniblinkExample: React.FC<{
   url: string; // could be action api or website url
 }> = ({ url }) => {
   const adapter = getWalletAdapter();
-  const { action } = useAction({ url, adapter });
+  const { action } = useAction({ url });
 
   if (!action) {
     return <ActivityIndicator />;
@@ -72,6 +73,7 @@ export const MiniblinkExample: React.FC<{
   return (
     <Miniblink
       action={action}
+      adapter={adapter}
       selector={(currentAction) =>
         currentAction.actions.find((a) => a.label === 'Donate')!
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "!**/.*"
   ],
   "scripts": {
-    "example:ios": "yarn workspace @dialectlabs/blinks-react-native-example ios",
+    "example": "yarn workspace @dialectlabs/blinks-react-native-example",
+    "example:ios": "yarn run example ios",
+    "example:android": "yarn run example android",
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "!**/.*"
   ],
   "scripts": {
-    "example": "yarn workspace @dialectlabs/blinks-react-native-example",
+    "example:ios": "yarn workspace @dialectlabs/blinks-react-native-example ios",
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
@@ -153,7 +153,7 @@
     "version": "0.38.2"
   },
   "dependencies": {
-    "@dialectlabs/blinks-core": "^0.13.1",
+    "@dialectlabs/blinks-core": "^0.14.1",
     "@react-native-community/datetimepicker": "^8.2.0",
     "@react-native-picker/picker": "^2.7.7",
     "@shopify/restyle": "^2.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,15 +1764,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dialectlabs/blinks-core@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "@dialectlabs/blinks-core@npm:0.13.1"
+"@dialectlabs/blinks-core@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "@dialectlabs/blinks-core@npm:0.14.1"
   dependencies:
     "@solana/web3.js": ^1.95.1
     nanoid: ^5.0.7
   peerDependencies:
     react: ">=18"
-  checksum: fb2b1d062c688089f8f51a683b3e152cd40926145715338449b35fd72631f68797967c60c54bc1d31b78aff701c6a44105300201eaf42c5885981923b7fc1c54
+  checksum: efea3dc9d3cfa6cfbabdedd6b2fd5b03ead575ab3bccd0919590edc8b3cc439c4d5c621bb581c09fd07c789b929e21e2698537e33538ff140187e6e824788663
   languageName: node
   linkType: hard
 
@@ -1798,7 +1798,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dialectlabs/blinks-react-native@workspace:."
   dependencies:
-    "@dialectlabs/blinks-core": ^0.13.1
+    "@dialectlabs/blinks-core": ^0.14.1
     "@react-native-community/datetimepicker": ^8.2.0
     "@react-native-picker/picker": ^2.7.7
     "@react-native/eslint-config": ^0.74.85


### PR DESCRIPTION
Bumps `blinks-core` package with the updated api, adjusts readme and example with new api

Resolves:
- https://github.com/dialectlabs/blinks/issues/38
- https://github.com/dialectlabs/blinks-react-native/issues/11