### PR TITLE
feat: add markdown support

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,13 +9,13 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@expo/metro-runtime": "~3.2.1",
+    "@expo/metro-runtime": "~3.2.3",
     "@solana/web3.js": "^1.95.2",
-    "expo": "~51.0.22",
+    "expo": "~51.0.39",
     "expo-status-bar": "~1.12.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.74.3",
+    "react-native": "0.74.5",
     "react-native-svg": "15.2.0",
     "react-native-web": "~0.19.10"
   },

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "@react-native-community/datetimepicker": "^8.2.0",
     "@react-native-picker/picker": "^2.7.7",
     "@shopify/restyle": "^2.4.4",
+    "react-native-markdown-display": "^7.0.2",
     "react-native-modal-datetime-picker": "^17.1.0"
   }
 }

--- a/src/ui/components/SimpleMarkdown.tsx
+++ b/src/ui/components/SimpleMarkdown.tsx
@@ -4,13 +4,14 @@ import Markdown, {
   MarkdownIt,
   type RenderRules,
 } from 'react-native-markdown-display';
-import { useTheme } from '../theme';
+import { type ColorVars, useTheme } from '../theme';
 import { confirmLinkTransition } from '../utils';
 import { Text } from './Text';
 
 interface Props {
   text: string;
   baseTextVariant?: 'caption' | 'text';
+  baseColor?: keyof ColorVars;
 }
 
 const LinkWithConfirm = ({
@@ -54,16 +55,25 @@ const rules: RenderRules = {
   },
 };
 
-export const SimpleMarkdown = ({ text, baseTextVariant = 'text' }: Props) => {
+export const SimpleMarkdown = ({
+  text,
+  baseTextVariant = 'text',
+  baseColor = 'textPrimary',
+}: Props) => {
   const theme = useTheme();
-  const commonHeadingParagraphStyle = {
+  const baseTextStyles = {
     ...theme.textVariants[baseTextVariant],
+    color: theme.colors[baseColor],
+  };
+
+  const commonHeadingParagraphStyle = {
+    ...baseTextStyles,
     marginTop: 0,
     marginBottom: theme.spacing['1'],
   };
 
   const commonCodeBlockStyle = {
-    ...theme.textVariants[baseTextVariant],
+    ...baseTextStyles,
     borderWidth: 0,
     backgroundColor: 'transparent',
     marginLeft: 0,
@@ -73,16 +83,13 @@ export const SimpleMarkdown = ({ text, baseTextVariant = 'text' }: Props) => {
 
   return (
     <Markdown
-      debugPrintTree={true}
       rules={rules}
       markdownit={MarkdownIt({
         typographer: true,
         linkify: true,
       })}
       style={{
-        text: {
-          ...theme.textVariants[baseTextVariant],
-        },
+        text: baseTextStyles,
         heading1: commonHeadingParagraphStyle,
         heading2: commonHeadingParagraphStyle,
         heading3: commonHeadingParagraphStyle,
@@ -117,9 +124,7 @@ export const SimpleMarkdown = ({ text, baseTextVariant = 'text' }: Props) => {
         tr: {
           borderBottomWidth: 0,
         },
-        ordered_list_icon: {
-          ...theme.textVariants[baseTextVariant],
-        },
+        ordered_list_icon: baseTextStyles,
         hr: {
           marginVertical: theme.spacing['1'],
         },

--- a/src/ui/components/SimpleMarkdown.tsx
+++ b/src/ui/components/SimpleMarkdown.tsx
@@ -1,0 +1,131 @@
+import type { PropsWithChildren } from 'react';
+import { Linking, type StyleProp, type TextStyle } from 'react-native';
+import Markdown, {
+  MarkdownIt,
+  type RenderRules,
+} from 'react-native-markdown-display';
+import { useTheme } from '../theme';
+import { confirmLinkTransition } from '../utils';
+import { Text } from './Text';
+
+interface Props {
+  text: string;
+  baseTextVariant?: 'caption' | 'text';
+}
+
+const LinkWithConfirm = ({
+  href,
+  children,
+  style,
+}: PropsWithChildren<{ href: string; style?: StyleProp<TextStyle> }>) => {
+  return (
+    <Text
+      style={style}
+      onPress={async () => {
+        const isOpenable = await Linking.canOpenURL(href);
+
+        if (!isOpenable) {
+          return;
+        }
+
+        confirmLinkTransition(href, {
+          onOk: () => {
+            Linking.openURL(href);
+          },
+          onCancel: () => {},
+        });
+      }}
+    >
+      {children}
+    </Text>
+  );
+};
+
+const rules: RenderRules = {
+  image: () => null,
+  link: (node, children, _, styles) => {
+    const href = node.attributes.href;
+
+    return (
+      <LinkWithConfirm key={node.key} href={href} style={styles.link}>
+        {children}
+      </LinkWithConfirm>
+    );
+  },
+};
+
+export const SimpleMarkdown = ({ text, baseTextVariant = 'text' }: Props) => {
+  const theme = useTheme();
+  const commonHeadingParagraphStyle = {
+    ...theme.textVariants[baseTextVariant],
+    marginTop: 0,
+    marginBottom: theme.spacing['1'],
+  };
+
+  const commonCodeBlockStyle = {
+    ...theme.textVariants[baseTextVariant],
+    borderWidth: 0,
+    backgroundColor: 'transparent',
+    marginLeft: 0,
+    paddingLeft: 0,
+    borderRadius: 0,
+  };
+
+  return (
+    <Markdown
+      debugPrintTree={true}
+      rules={rules}
+      markdownit={MarkdownIt({
+        typographer: true,
+        linkify: true,
+      })}
+      style={{
+        text: {
+          ...theme.textVariants[baseTextVariant],
+        },
+        heading1: commonHeadingParagraphStyle,
+        heading2: commonHeadingParagraphStyle,
+        heading3: commonHeadingParagraphStyle,
+        heading4: commonHeadingParagraphStyle,
+        heading5: commonHeadingParagraphStyle,
+        heading6: commonHeadingParagraphStyle,
+        paragraph: commonHeadingParagraphStyle,
+        code_block: commonCodeBlockStyle,
+        code_inline: commonCodeBlockStyle,
+        fence: commonCodeBlockStyle,
+        blockquote: {
+          backgroundColor: 'transparent',
+          borderLeftWidth: 0,
+          paddingHorizontal: 0,
+          paddingVertical: 0,
+          marginLeft: 0,
+        },
+        table: {
+          borderWidth: 0,
+          borderRadius: 0,
+        },
+        td: {
+          padding: 0,
+          paddingHorizontal: theme.spacing['0.5'],
+          paddingVertical: theme.spacing['1'],
+        },
+        th: {
+          padding: 0,
+          paddingHorizontal: theme.spacing['0.5'],
+          paddingVertical: theme.spacing['1'],
+        },
+        tr: {
+          borderBottomWidth: 0,
+        },
+        ordered_list_icon: {
+          ...theme.textVariants[baseTextVariant],
+        },
+        hr: {
+          marginVertical: theme.spacing['1'],
+        },
+      }}
+    >
+      {text}
+    </Markdown>
+  );
+};

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -4,5 +4,6 @@ export { Button } from './Button';
 export { InputContainer } from './InputContainer';
 export { Link } from './Link';
 export { PickerModal } from './PickerModal';
+export { SimpleMarkdown } from './SimpleMarkdown';
 export { Snackbar } from './Snackbar';
 export { Text } from './Text';

--- a/src/ui/hooks/useIsolatedLayoutPropNormalizer.ts
+++ b/src/ui/hooks/useIsolatedLayoutPropNormalizer.ts
@@ -8,8 +8,9 @@ import {
   SingleValueActionComponent,
 } from '@dialectlabs/blinks-core';
 import { useCallback, useMemo } from 'react';
-import { Alert, Linking } from 'react-native';
+import { Linking } from 'react-native';
 import type { IsolatedLayoutProps } from '../types';
+import { confirmLinkTransition } from '../utils';
 import { buttonLabelMap, buttonVariantMap } from './ui-mappers';
 
 const SOFT_LIMIT_FORM_INPUTS = 10;
@@ -49,25 +50,13 @@ export const useIsolatedLayoutPropNormalizer = ({
           }
 
           if (extra.type === 'external-link') {
-            Alert.alert(
-              'External Link',
-              `This action redirects to the website: ${extra.data.externalLink}, the link will open in your browser`,
-              [
-                {
-                  text: 'Cancel',
-                  style: 'cancel',
-                  onPress: () => extra.onCancel?.(),
-                },
-                {
-                  text: 'OK',
-                  isPreferred: true,
-                  onPress: () => {
-                    Linking.openURL(extra.data.externalLink);
-                    extra.onNext();
-                  },
-                },
-              ],
-            );
+            confirmLinkTransition(extra.data.externalLink, {
+              onOk: () => {
+                Linking.openURL(extra.data.externalLink);
+                extra.onNext();
+              },
+              onCancel: () => extra.onCancel?.(),
+            });
           }
         },
       };

--- a/src/ui/hooks/useLayoutPropNormalizer.ts
+++ b/src/ui/hooks/useLayoutPropNormalizer.ts
@@ -8,8 +8,9 @@ import {
   SingleValueActionComponent,
 } from '@dialectlabs/blinks-core';
 import { useMemo } from 'react';
-import { Alert, Linking } from 'react-native';
+import { Linking } from 'react-native';
 import type { LayoutProps } from '../types';
+import { confirmLinkTransition } from '../utils';
 import { buttonLabelMap, buttonVariantMap } from './ui-mappers';
 
 const SOFT_LIMIT_BUTTONS = 10;
@@ -86,25 +87,13 @@ export const useLayoutPropNormalizer = ({
         }
 
         if (extra.type === 'external-link') {
-          Alert.alert(
-            'External Link',
-            `This action redirects to the website: ${extra.data.externalLink}, the link will open in your browser`,
-            [
-              {
-                text: 'Cancel',
-                style: 'cancel',
-                onPress: () => extra.onCancel?.(),
-              },
-              {
-                text: 'OK',
-                isPreferred: true,
-                onPress: () => {
-                  Linking.openURL(extra.data.externalLink);
-                  extra.onNext();
-                },
-              },
-            ],
-          );
+          confirmLinkTransition(extra.data.externalLink, {
+            onOk: () => {
+              Linking.openURL(extra.data.externalLink);
+              extra.onNext();
+            },
+            onCancel: () => extra.onCancel?.(),
+          });
         }
       },
     };

--- a/src/ui/layout/ActionInput/ActionCheckboxGroup.tsx
+++ b/src/ui/layout/ActionInput/ActionCheckboxGroup.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
-import { Box, Text } from '../../components';
+import { Box, SimpleMarkdown, Text } from '../../components';
 import { CheckBoxIcon } from '../../icons';
 import type {
   BorderRadiiVars,
@@ -222,7 +222,7 @@ export const ActionCheckboxGroup = ({
           variant="caption"
           {...standaloneProps.text}
         >
-          {finalDescription}
+          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
         </Text>
       )}
     </Box>

--- a/src/ui/layout/ActionInput/ActionCheckboxGroup.tsx
+++ b/src/ui/layout/ActionInput/ActionCheckboxGroup.tsx
@@ -217,13 +217,13 @@ export const ActionCheckboxGroup = ({
         />
       )}
       {finalDescription && (
-        <Text
-          color={getDescriptionColor(state.valid, touched)}
-          variant="caption"
-          {...standaloneProps.text}
-        >
-          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
-        </Text>
+        <Box {...standaloneProps.text}>
+          <SimpleMarkdown
+            text={finalDescription}
+            baseTextVariant="caption"
+            baseColor={getDescriptionColor(state.valid, touched)}
+          />
+        </Box>
       )}
     </Box>
   );

--- a/src/ui/layout/ActionInput/ActionDateInput.tsx
+++ b/src/ui/layout/ActionInput/ActionDateInput.tsx
@@ -145,13 +145,13 @@ const DateInput = ({
         )}
       </InputContainer>
       {finalDescription && (
-        <Text
-          color={getDescriptionColor(isValid, isTouched)}
-          py={1}
-          variant="caption"
-        >
-          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
-        </Text>
+        <Box py={1}>
+          <SimpleMarkdown
+            text={finalDescription}
+            baseTextVariant="caption"
+            baseColor={getDescriptionColor(isValid, isTouched)}
+          />
+        </Box>
       )}
       <DateTimePickerModal
         minimumDate={minDate ?? undefined}

--- a/src/ui/layout/ActionInput/ActionDateInput.tsx
+++ b/src/ui/layout/ActionInput/ActionDateInput.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
-import { Box, InputContainer, Text } from '../../components';
+import { Box, InputContainer, SimpleMarkdown, Text } from '../../components';
 import { CalendarIcon } from '../../icons';
 import { useTheme } from '../../theme';
 import type { InputProps } from '../../types';
@@ -150,7 +150,7 @@ const DateInput = ({
           py={1}
           variant="caption"
         >
-          {finalDescription}
+          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
         </Text>
       )}
       <DateTimePickerModal

--- a/src/ui/layout/ActionInput/ActionDateTimeInput.tsx
+++ b/src/ui/layout/ActionInput/ActionDateTimeInput.tsx
@@ -241,14 +241,13 @@ const DateTimeInput = ({
         )}
       </Box>
       {finalDescription && (
-        <Text
-          color={getDescriptionColor(isValid, isTouched)}
-          variant="caption"
-          py={1}
-          {...standaloneProps.text}
-        >
-          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
-        </Text>
+        <Box py={1} {...standaloneProps.text}>
+          <SimpleMarkdown
+            text={finalDescription}
+            baseTextVariant="caption"
+            baseColor={getDescriptionColor(isValid, isTouched)}
+          />
+        </Box>
       )}
       <DateTimePickerModal
         date={displayedDate}

--- a/src/ui/layout/ActionInput/ActionDateTimeInput.tsx
+++ b/src/ui/layout/ActionInput/ActionDateTimeInput.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
-import { Box, InputContainer, Text } from '../../components';
+import { Box, InputContainer, SimpleMarkdown, Text } from '../../components';
 import { CalendarIcon, ClockIcon } from '../../icons';
 import type {
   BorderRadiiVars,
@@ -247,7 +247,7 @@ const DateTimeInput = ({
           py={1}
           {...standaloneProps.text}
         >
-          {finalDescription}
+          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
         </Text>
       )}
       <DateTimePickerModal

--- a/src/ui/layout/ActionInput/ActionNumberInput.tsx
+++ b/src/ui/layout/ActionInput/ActionNumberInput.tsx
@@ -4,7 +4,7 @@ import {
   TextInput,
   type TextInputChangeEventData,
 } from 'react-native';
-import { Box, InputContainer, SimpleMarkdown, Text } from '../../components';
+import { Box, InputContainer, SimpleMarkdown } from '../../components';
 import NumberIcon from '../../icons/NumberIcon';
 import { useTheme } from '../../theme';
 import type { InputProps } from '../../types';
@@ -139,13 +139,13 @@ export const ActionNumberInput = ({
         )}
       </InputContainer>
       {finalDescription && (
-        <Text
-          color={getDescriptionColor(isValid, isTouched)}
-          variant="caption"
-          py={1}
-        >
-          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
-        </Text>
+        <Box py={1}>
+          <SimpleMarkdown
+            text={finalDescription}
+            baseTextVariant="caption"
+            baseColor={getDescriptionColor(isValid, isTouched)}
+          />
+        </Box>
       )}
     </Box>
   );

--- a/src/ui/layout/ActionInput/ActionNumberInput.tsx
+++ b/src/ui/layout/ActionInput/ActionNumberInput.tsx
@@ -4,7 +4,7 @@ import {
   TextInput,
   type TextInputChangeEventData,
 } from 'react-native';
-import { Box, InputContainer, Text } from '../../components';
+import { Box, InputContainer, SimpleMarkdown, Text } from '../../components';
 import NumberIcon from '../../icons/NumberIcon';
 import { useTheme } from '../../theme';
 import type { InputProps } from '../../types';
@@ -144,7 +144,7 @@ export const ActionNumberInput = ({
           variant="caption"
           py={1}
         >
-          {finalDescription}
+          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
         </Text>
       )}
     </Box>

--- a/src/ui/layout/ActionInput/ActionRadioGroup.tsx
+++ b/src/ui/layout/ActionInput/ActionRadioGroup.tsx
@@ -147,13 +147,13 @@ export const ActionRadioGroup = ({
         />
       )}
       {description && (
-        <Text
-          color={!isValid ? 'textError' : 'textSecondary'}
-          variant="caption"
-          {...standaloneProps.text}
-        >
-          <SimpleMarkdown text={description} baseTextVariant="caption" />
-        </Text>
+        <Box {...standaloneProps.text}>
+          <SimpleMarkdown
+            text={description}
+            baseTextVariant="caption"
+            baseColor={!isValid ? 'textError' : 'textSecondary'}
+          />
+        </Box>
       )}
     </Box>
   );

--- a/src/ui/layout/ActionInput/ActionRadioGroup.tsx
+++ b/src/ui/layout/ActionInput/ActionRadioGroup.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
-import { Box, Text } from '../../components';
+import { Box, SimpleMarkdown, Text } from '../../components';
 import {
   type BorderRadiiVars,
   type ColorVars,
@@ -152,7 +152,7 @@ export const ActionRadioGroup = ({
           variant="caption"
           {...standaloneProps.text}
         >
-          {description}
+          <SimpleMarkdown text={description} baseTextVariant="caption" />
         </Text>
       )}
     </Box>

--- a/src/ui/layout/ActionInput/ActionSelect.tsx
+++ b/src/ui/layout/ActionInput/ActionSelect.tsx
@@ -1,7 +1,13 @@
 import { Picker } from '@react-native-picker/picker';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform, TouchableOpacity } from 'react-native';
-import { Box, InputContainer, PickerModal, Text } from '../../components';
+import {
+  Box,
+  InputContainer,
+  PickerModal,
+  SimpleMarkdown,
+  Text,
+} from '../../components';
 import { ChevronDownIcon } from '../../icons';
 import { useTheme } from '../../theme';
 import type { InputProps } from '../../types';
@@ -120,7 +126,7 @@ export const ActionSelect = ({
           variant="caption"
           py={1}
         >
-          {description}
+          <SimpleMarkdown text={description} baseTextVariant="caption" />
         </Text>
       )}
       {Platform.OS === 'android' && (

--- a/src/ui/layout/ActionInput/ActionSelect.tsx
+++ b/src/ui/layout/ActionInput/ActionSelect.tsx
@@ -121,13 +121,13 @@ export const ActionSelect = ({
         )}
       </InputContainer>
       {description && (
-        <Text
-          color={getDescriptionColor(isValid, isTouched)}
-          variant="caption"
-          py={1}
-        >
-          <SimpleMarkdown text={description} baseTextVariant="caption" />
-        </Text>
+        <Box py={1}>
+          <SimpleMarkdown
+            text={description}
+            baseTextVariant="caption"
+            baseColor={getDescriptionColor(isValid, isTouched)}
+          />
+        </Box>
       )}
       {Platform.OS === 'android' && (
         <Picker

--- a/src/ui/layout/ActionInput/ActionTextInput.tsx
+++ b/src/ui/layout/ActionInput/ActionTextInput.tsx
@@ -6,7 +6,7 @@ import {
   type TextInputChangeEventData,
 } from 'react-native';
 import type { SvgProps } from 'react-native-svg';
-import { Box, InputContainer, SimpleMarkdown, Text } from '../../components';
+import { Box, InputContainer, SimpleMarkdown } from '../../components';
 import { EnvelopeIcon, LinkIcon } from '../../icons';
 import { useTheme } from '../../theme';
 import type { InputProps } from '../../types';
@@ -191,13 +191,13 @@ export const ActionTextInput = ({
         )}
       </InputContainer>
       {finalDescription && (
-        <Text
-          color={getDescriptionColor(isValid, isTouched)}
-          variant="caption"
-          py={1}
-        >
-          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
-        </Text>
+        <Box py={1}>
+          <SimpleMarkdown
+            text={finalDescription}
+            baseTextVariant="caption"
+            baseColor={getDescriptionColor(isValid, isTouched)}
+          />
+        </Box>
       )}
     </Box>
   );

--- a/src/ui/layout/ActionInput/ActionTextInput.tsx
+++ b/src/ui/layout/ActionInput/ActionTextInput.tsx
@@ -6,7 +6,7 @@ import {
   type TextInputChangeEventData,
 } from 'react-native';
 import type { SvgProps } from 'react-native-svg';
-import { Box, InputContainer, Text } from '../../components';
+import { Box, InputContainer, SimpleMarkdown, Text } from '../../components';
 import { EnvelopeIcon, LinkIcon } from '../../icons';
 import { useTheme } from '../../theme';
 import type { InputProps } from '../../types';
@@ -196,7 +196,7 @@ export const ActionTextInput = ({
           variant="caption"
           py={1}
         >
-          {finalDescription}
+          <SimpleMarkdown text={finalDescription} baseTextVariant="caption" />
         </Text>
       )}
     </Box>

--- a/src/ui/layout/BlinkLayout.tsx
+++ b/src/ui/layout/BlinkLayout.tsx
@@ -46,9 +46,11 @@ export const BlinkLayout = ({
         <Text mb={1.5} variant="h3" fontWeight="600" color="textPrimary">
           {title.substring(0, SOFT_LIMIT_TITLE_LENGTH)}
         </Text>
-        <Text mb="gap" variant="text" color="textSecondary">
-          {description && <SimpleMarkdown text={description} />}
-        </Text>
+        <Box mb="gap">
+          {description && (
+            <SimpleMarkdown text={description} baseColor="textSecondary" />
+          )}
+        </Box>
 
         {!supportability.isSupported ? (
           <NotSupportedBlock message={supportability?.message} />

--- a/src/ui/layout/BlinkLayout.tsx
+++ b/src/ui/layout/BlinkLayout.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '../components';
+import { Box, SimpleMarkdown, Text } from '../components';
 import type { LayoutProps } from '../types';
 import { DisclaimerType } from '../types';
 import { ActionContent } from './ActionContent';
@@ -43,11 +43,11 @@ export const BlinkLayout = ({
           securityState={securityState}
         />
 
-        <Text mb={0.5} variant="h3" fontWeight="600" color="textPrimary">
+        <Text mb={1.5} variant="h3" fontWeight="600" color="textPrimary">
           {title.substring(0, SOFT_LIMIT_TITLE_LENGTH)}
         </Text>
         <Text mb="gap" variant="text" color="textSecondary">
-          {description}
+          {description && <SimpleMarkdown text={description} />}
         </Text>
 
         {!supportability.isSupported ? (

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -1,0 +1,23 @@
+import { Alert } from 'react-native';
+
+export const confirmLinkTransition = (
+  url: string,
+  { onOk, onCancel }: { onOk: () => void; onCancel: () => void },
+) => {
+  Alert.alert(
+    'External Link',
+    `This action redirects to the website: ${url}, the link will open in your browser`,
+    [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+        onPress: onCancel,
+      },
+      {
+        text: 'OK',
+        isPreferred: true,
+        onPress: onOk,
+      },
+    ],
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,6 +1816,7 @@ __metadata:
     react: 18.2.0
     react-native: 0.74.3
     react-native-builder-bob: ^0.26.0
+    react-native-markdown-display: ^7.0.2
     react-native-modal-datetime-picker: ^17.1.0
     react-native-svg: ^15.4.0
     release-it: ^15.0.0
@@ -5070,6 +5071,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelize@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "camelize@npm:1.0.1"
+  checksum: 91d8611d09af725e422a23993890d22b2b72b4cabf7239651856950c76b4bf53fe0d0da7c5e4db05180e898e4e647220e78c9fbc976113bd96d603d1fcbfcb99
+  languageName: node
+  linkType: hard
+
 "caniuse-lite@npm:^1.0.30001640":
   version: 1.0.30001643
   resolution: "caniuse-lite@npm:1.0.30001643"
@@ -5607,6 +5615,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-color-keywords@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "css-color-keywords@npm:1.0.0"
+  checksum: 8f125e3ad477bd03c77b533044bd9e8a6f7c0da52d49bbc0bbe38327b3829d6ba04d368ca49dd9ff3b667d2fc8f1698d891c198bbf8feade1a5501bf5a296408
+  languageName: node
+  linkType: hard
+
 "css-in-js-utils@npm:^3.1.0":
   version: 3.1.0
   resolution: "css-in-js-utils@npm:3.1.0"
@@ -5626,6 +5641,17 @@ __metadata:
     domutils: ^3.0.1
     nth-check: ^2.0.1
   checksum: 2772c049b188d3b8a8159907192e926e11824aea525b8282981f72ba3f349cf9ecd523fdf7734875ee2cb772246c22117fc062da105b6d59afe8dcd5c99c9bda
+  languageName: node
+  linkType: hard
+
+"css-to-react-native@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "css-to-react-native@npm:3.2.0"
+  dependencies:
+    camelize: ^1.0.0
+    css-color-keywords: ^1.0.0
+    postcss-value-parser: ^4.0.2
+  checksum: 263be65e805aef02c3f20c064665c998a8c35293e1505dbe6e3054fb186b01a9897ac6cf121f9840e5a9dfe3fb3994f6fcd0af84a865f1df78ba5bf89e77adce
   languageName: node
   linkType: hard
 
@@ -6184,6 +6210,13 @@ __metadata:
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 853f8ebd5b425d350bffa97dd6958143179a5938352ccae092c62d1267c4e392a039be1bae7d51b6e4ffad25f51f9617531fedf5237f15df302ccfb452cbf2d7
+  languageName: node
+  linkType: hard
+
+"entities@npm:~2.0.0":
+  version: 2.0.3
+  resolution: "entities@npm:2.0.3"
+  checksum: 5a7899fcc622e0d76afdeafe4c58a6b40ae3a8ee4772e5825a648c11a2ca324a9a02515386f512e466baac4aeb551f3d3b79eaece5cd98369b9f8601be336b1a
   languageName: node
   linkType: hard
 
@@ -9956,6 +9989,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "linkify-it@npm:2.2.0"
+  dependencies:
+    uc.micro: ^1.0.1
+  checksum: d198871d0b3f3cfdb745dae564bfd6743474f20cd0ef1057e6ca29451834749e7f3da52b59b4de44e98f31a1e5c71bdad160490d4ae54de251cbcde57e4d7837
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^3.0.0":
   version: 3.0.0
   resolution: "locate-path@npm:3.0.0"
@@ -10208,6 +10250,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "markdown-it@npm:10.0.0"
+  dependencies:
+    argparse: ^1.0.7
+    entities: ~2.0.0
+    linkify-it: ^2.0.0
+    mdurl: ^1.0.1
+    uc.micro: ^1.0.5
+  bin:
+    markdown-it: bin/markdown-it.js
+  checksum: 69f5ee640cbebb451b80d3cce308fff7230767e05c0f8c206a1e413775b7a6e5a08e91e9f3ec59f9b5c5a45493f9ce7ac089379cffb60c9d3e6677ed9d535086
+  languageName: node
+  linkType: hard
+
 "marky@npm:^1.2.2":
   version: 1.2.5
   resolution: "marky@npm:1.2.5"
@@ -10259,6 +10316,13 @@ __metadata:
   version: 2.0.14
   resolution: "mdn-data@npm:2.0.14"
   checksum: 9d0128ed425a89f4cba8f787dca27ad9408b5cb1b220af2d938e2a0629d17d879a34d2cb19318bdb26c3f14c77dd5dfbae67211f5caaf07b61b1f2c5c8c7dc16
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "mdurl@npm:1.0.1"
+  checksum: 71731ecba943926bfbf9f9b51e28b5945f9411c4eda80894221b47cc105afa43ba2da820732b436f0798fd3edbbffcd1fc1415843c41a87fea08a41cc1e3d02b
   languageName: node
   linkType: hard
 
@@ -11771,7 +11835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-value-parser@npm:^4.2.0":
+"postcss-value-parser@npm:^4.0.2, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
@@ -11941,7 +12005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.5.10, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -12151,6 +12215,30 @@ __metadata:
   bin:
     bob: bin/bob
   checksum: 60b720ce74b5571ec293a10d00b26dc923d62a0c07222548499b90878e72be3ddd77fb33b62144ab0a0f405049a3747376742b9499cb73f9e851da0ce0e17204
+  languageName: node
+  linkType: hard
+
+"react-native-fit-image@npm:^1.5.5":
+  version: 1.5.5
+  resolution: "react-native-fit-image@npm:1.5.5"
+  dependencies:
+    prop-types: ^15.5.10
+  checksum: 2f3ce06b43191efe3a4bd0698a4117342d821455c96433e9561d50f156ee446d2c449bf9e0908f9a8b7bbb8f95c02478d4fca8d8d103f38b6ce3b8b75557af15
+  languageName: node
+  linkType: hard
+
+"react-native-markdown-display@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "react-native-markdown-display@npm:7.0.2"
+  dependencies:
+    css-to-react-native: ^3.0.0
+    markdown-it: ^10.0.0
+    prop-types: ^15.7.2
+    react-native-fit-image: ^1.5.5
+  peerDependencies:
+    react: ">=16.2.0"
+    react-native: ">=0.50.4"
+  checksum: 69c64f2d21f4ebf001c71d6dff31ef5e13946a0b46b2d2f2830efa89d648afbd8c336be8552264b42d693446e13a3f81fdbfdd5aa9b20878441acabd59f0a54e
   languageName: node
   linkType: hard
 
@@ -14166,6 +14254,13 @@ __metadata:
   version: 1.0.38
   resolution: "ua-parser-js@npm:1.0.38"
   checksum: d0772b22b027338d806ab17d1ac2896ee7485bdf9217c526028159f3cd6bb10272bb18f6196d2f94dde83e3b36dc9d2533daf08a414764f6f4f1844842383838
+  languageName: node
+  linkType: hard
+
+"uc.micro@npm:^1.0.1, uc.micro@npm:^1.0.5":
+  version: 1.0.6
+  resolution: "uc.micro@npm:1.0.6"
+  checksum: 6898bb556319a38e9cf175e3628689347bd26fec15fc6b29fa38e0045af63075ff3fea4cf1fdba9db46c9f0cbf07f2348cd8844889dd31ebd288c29fe0d27e7a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:7.2.0":
+  version: 7.2.0
+  resolution: "@babel/generator@npm:7.2.0"
+  dependencies:
+    "@babel/types": ^7.2.0
+    jsesc: ^2.5.1
+    lodash: ^4.17.10
+    source-map: ^0.5.0
+    trim-right: ^1.0.1
+  checksum: 0cfa36e3fee34908194e85a87dfcd2a92425e3810396556ae0c7987707754f1a2502cd66590fec0a5b7bf532ec021b8e2925a1119db54ed5b48f1e3c43145891
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.20.0, @babel/generator@npm:^7.20.5, @babel/generator@npm:^7.24.8, @babel/generator@npm:^7.24.9, @babel/generator@npm:^7.7.2":
   version: 7.24.10
   resolution: "@babel/generator@npm:7.24.10"
@@ -322,10 +335,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-string-parser@npm:7.25.9"
+  checksum: 6435ee0849e101681c1849868278b5aee82686ba2c1e27280e5e8aca6233af6810d39f8e4e693d2f2a44a3728a6ccfd66f72d71826a94105b86b731697cdfa99
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
   checksum: 6799ab117cefc0ecd35cd0b40ead320c621a298ecac88686a14cffceaac89d80cdb3c178f969861bf5fa5e4f766648f9161ea0752ecfe080d8e89e3147270257
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-validator-identifier@npm:7.25.9"
+  checksum: 5b85918cb1a92a7f3f508ea02699e8d2422fe17ea8e82acd445006c0ef7520fbf48e3dbcdaf7b0a1d571fc3a2715a29719e5226636cb6042e15fe6ed2a590944
   languageName: node
   linkType: hard
 
@@ -1757,6 +1784,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:^7.19.0, @babel/types@npm:^7.2.0":
+  version: 7.26.0
+  resolution: "@babel/types@npm:7.26.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.25.9
+    "@babel/helper-validator-identifier": ^7.25.9
+  checksum: a3dd37dabac693018872da96edb8c1843a605c1bfacde6c3f504fba79b972426a6f24df70aa646356c0c1b19bdd2c722c623c684a996c002381071680602280d
+  languageName: node
+  linkType: hard
+
 "@bcoe/v8-coverage@npm:^0.2.3":
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
@@ -1781,14 +1818,14 @@ __metadata:
   resolution: "@dialectlabs/blinks-react-native-example@workspace:example"
   dependencies:
     "@babel/core": ^7.20.0
-    "@expo/metro-runtime": ~3.2.1
+    "@expo/metro-runtime": ~3.2.3
     "@solana/web3.js": ^1.95.2
     babel-plugin-module-resolver: ^5.0.0
-    expo: ~51.0.22
+    expo: ~51.0.39
     expo-status-bar: ~1.12.1
     react: 18.2.0
     react-dom: 18.2.0
-    react-native: 0.74.3
+    react-native: 0.74.5
     react-native-svg: 15.2.0
     react-native-web: ~0.19.10
   languageName: unknown
@@ -1887,9 +1924,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/cli@npm:0.18.25":
-  version: 0.18.25
-  resolution: "@expo/cli@npm:0.18.25"
+"@expo/cli@npm:0.18.31":
+  version: 0.18.31
+  resolution: "@expo/cli@npm:0.18.31"
   dependencies:
     "@babel/runtime": ^7.20.0
     "@expo/code-signing-certificates": 0.0.5
@@ -1899,11 +1936,11 @@ __metadata:
     "@expo/env": ~0.3.0
     "@expo/image-utils": ^0.5.0
     "@expo/json-file": ^8.3.0
-    "@expo/metro-config": ~0.18.6
+    "@expo/metro-config": 0.18.11
     "@expo/osascript": ^2.0.31
     "@expo/package-manager": ^1.5.0
     "@expo/plist": ^0.1.0
-    "@expo/prebuild-config": 7.0.8
+    "@expo/prebuild-config": 7.0.9
     "@expo/rudder-sdk-node": 1.1.1
     "@expo/spawn-async": ^1.7.2
     "@expo/xcpretty": ^4.3.0
@@ -1970,7 +2007,7 @@ __metadata:
     ws: ^8.12.1
   bin:
     expo-internal: build/bin/cli
-  checksum: 79581f13b1afe4886a90d61952f865c7b0b622c497f38378a18991a7f8e3d54423e4eee3c9d634c630df61e2f8372e747ac00c0091c638cb38ac9c525e697263
+  checksum: f8f1075d6f7243110ec53817277b2804898b2ae7d102a44be7621ee0a4369f075a1e0ca2b73d8f821d9c472bbf6c144091033c20618df5aef89b69738305cfc2
   languageName: node
   linkType: hard
 
@@ -1984,7 +2021,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/config-plugins@npm:8.0.8, @expo/config-plugins@npm:~8.0.8":
+"@expo/config-plugins@npm:8.0.11":
+  version: 8.0.11
+  resolution: "@expo/config-plugins@npm:8.0.11"
+  dependencies:
+    "@expo/config-types": ^51.0.3
+    "@expo/json-file": ~8.3.0
+    "@expo/plist": ^0.1.0
+    "@expo/sdk-runtime-versions": ^1.0.0
+    chalk: ^4.1.2
+    debug: ^4.3.1
+    find-up: ~5.0.0
+    getenv: ^1.0.0
+    glob: 7.1.6
+    resolve-from: ^5.0.0
+    semver: ^7.5.4
+    slash: ^3.0.0
+    slugify: ^1.6.6
+    xcode: ^3.0.1
+    xml2js: 0.6.0
+  checksum: 084b20f6254d28644fbfde13cbf4b155c9d965a7ea44c25e67d1ee8d3675570593e8233291948813c0832e03a26ee600676fe39d78f11e388b62555c537d8463
+  languageName: node
+  linkType: hard
+
+"@expo/config-plugins@npm:~8.0.8":
   version: 8.0.8
   resolution: "@expo/config-plugins@npm:8.0.8"
   dependencies:
@@ -2014,7 +2074,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/config@npm:9.0.3, @expo/config@npm:~9.0.0, @expo/config@npm:~9.0.0-beta.0":
+"@expo/config-types@npm:^51.0.3":
+  version: 51.0.3
+  resolution: "@expo/config-types@npm:51.0.3"
+  checksum: c46def814a5e0d6c8358b9767a89f51239f4f1c3b4a5305ffcfa1a86e4360ac40de54a65f7c6e787be7656e4144c99a050e98b600a1edd3d6e8e20c83d8e107b
+  languageName: node
+  linkType: hard
+
+"@expo/config@npm:9.0.4":
+  version: 9.0.4
+  resolution: "@expo/config@npm:9.0.4"
+  dependencies:
+    "@babel/code-frame": ~7.10.4
+    "@expo/config-plugins": ~8.0.8
+    "@expo/config-types": ^51.0.3
+    "@expo/json-file": ^8.3.0
+    getenv: ^1.0.0
+    glob: 7.1.6
+    require-from-string: ^2.0.2
+    resolve-from: ^5.0.0
+    semver: ^7.6.0
+    slugify: ^1.3.4
+    sucrase: 3.34.0
+  checksum: a00b2690a1abbfd83f419c436dcff8590d1e8c8c0a598339ae30da57aedde49564e5bd5f71edf4d634ebe079c4008a64eb9850ee4cf69592a7506c71a36f3132
+  languageName: node
+  linkType: hard
+
+"@expo/config@npm:~9.0.0, @expo/config@npm:~9.0.0-beta.0":
   version: 9.0.3
   resolution: "@expo/config@npm:9.0.3"
   dependencies:
@@ -2096,9 +2182,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/metro-config@npm:0.18.9":
-  version: 0.18.9
-  resolution: "@expo/metro-config@npm:0.18.9"
+"@expo/metro-config@npm:0.18.11":
+  version: 0.18.11
+  resolution: "@expo/metro-config@npm:0.18.11"
   dependencies:
     "@babel/core": ^7.20.0
     "@babel/generator": ^7.20.5
@@ -2118,42 +2204,16 @@ __metadata:
     lightningcss: ~1.19.0
     postcss: ~8.4.32
     resolve-from: ^5.0.0
-  checksum: 720bb621cf037e3183d4cec6be4773ba28c0b602a43cbd156637ffaebb279881a22578eaa4e106203a1664df1f521a9e5602106de843997914a97c95bcad22f2
+  checksum: 4de79b97c6d818a487c6eaa83a55d3d9d1a1b28262507d74ad407fa22c2c32658d2cd2fa38babf82c32cf58239aff2c5d85e130609eaa34ed29a8e20a295cd7f
   languageName: node
   linkType: hard
 
-"@expo/metro-config@npm:~0.18.6":
-  version: 0.18.8
-  resolution: "@expo/metro-config@npm:0.18.8"
-  dependencies:
-    "@babel/core": ^7.20.0
-    "@babel/generator": ^7.20.5
-    "@babel/parser": ^7.20.0
-    "@babel/types": ^7.20.0
-    "@expo/config": ~9.0.0-beta.0
-    "@expo/env": ~0.3.0
-    "@expo/json-file": ~8.3.0
-    "@expo/spawn-async": ^1.7.2
-    chalk: ^4.1.0
-    debug: ^4.3.2
-    find-yarn-workspace-root: ~2.0.0
-    fs-extra: ^9.1.0
-    getenv: ^1.0.0
-    glob: ^7.2.3
-    jsc-safe-url: ^0.2.4
-    lightningcss: ~1.19.0
-    postcss: ~8.4.32
-    resolve-from: ^5.0.0
-  checksum: 04f45ee37878f137ff23a7f96950e7ac799dbd09b38d7e408345e4dae69611b14a418d0454f15006c1720516773ee1fa30832f9d8602261259296f41c2ebe1a1
-  languageName: node
-  linkType: hard
-
-"@expo/metro-runtime@npm:~3.2.1":
-  version: 3.2.1
-  resolution: "@expo/metro-runtime@npm:3.2.1"
+"@expo/metro-runtime@npm:~3.2.3":
+  version: 3.2.3
+  resolution: "@expo/metro-runtime@npm:3.2.3"
   peerDependencies:
     react-native: "*"
-  checksum: 61bdbe9ff63ac9a72e3cb416619b0393c9e6985562e2e46d94c033db6d86c41a71d70bdf9e795c7eb1cb97536031f408d55229d629c6ea4bc4ca6b82d1dcf999
+  checksum: 138fff0f018f6d39346984c82c843979c4588ed04695bdb76cd80fd1081d79c0503ad961a8f632a642024c758f2757edf6b7e2272adc6f207aa0ed84726fabdc
   languageName: node
   linkType: hard
 
@@ -2198,13 +2258,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/prebuild-config@npm:7.0.8":
-  version: 7.0.8
-  resolution: "@expo/prebuild-config@npm:7.0.8"
+"@expo/prebuild-config@npm:7.0.9":
+  version: 7.0.9
+  resolution: "@expo/prebuild-config@npm:7.0.9"
   dependencies:
     "@expo/config": ~9.0.0-beta.0
     "@expo/config-plugins": ~8.0.8
-    "@expo/config-types": ^51.0.0-unreleased
+    "@expo/config-types": ^51.0.3
     "@expo/image-utils": ^0.5.0
     "@expo/json-file": ^8.3.0
     "@react-native/normalize-colors": 0.74.85
@@ -2215,7 +2275,7 @@ __metadata:
     xml2js: 0.6.0
   peerDependencies:
     expo-modules-autolinking: ">=0.8.1"
-  checksum: b3715b10aa5aa9e60e97802feaaa6ddca4330752ec566d9f272e23417d00e2a298b6cc2f0d33f8a46a3c907f10b862d2975b737ba10e194ac834eae48847923b
+  checksum: 358ab0db1dea3a8c623314c462ebfb3d55b4be3fd854aa6f83e41052eea4eeec69532588cce480637aa9d9fb0e6670217812aee99f914c494972db3c13b8b11d
   languageName: node
   linkType: hard
 
@@ -2250,12 +2310,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/vector-icons@npm:^14.0.0":
-  version: 14.0.2
-  resolution: "@expo/vector-icons@npm:14.0.2"
+"@expo/vector-icons@npm:^14.0.3":
+  version: 14.0.4
+  resolution: "@expo/vector-icons@npm:14.0.4"
   dependencies:
     prop-types: ^15.8.1
-  checksum: 49e27ff52eb138745313fa2c39863fb762230b0089b910d668d7f2c06b7e71a0249dc3a26bfc8725d07bdfaadab1dbcbce087b34dfc244b00a15fc02fe4866e2
+  checksum: 31bd5d4e4e2f0b0620b7e8b55b0c5691875cf57c5737bd0ccef0017d0e7abee66352f3d66a58997b719bd0720cccf8f5119503c69fe1a30398747306ebefeb6e
   languageName: node
   linkType: hard
 
@@ -2593,6 +2653,17 @@ __metadata:
     slash: ^3.0.0
     write-file-atomic: ^4.0.2
   checksum: 0f8ac9f413903b3cb6d240102db848f2a354f63971ab885833799a9964999dd51c388162106a807f810071f864302cdd8e3f0c241c29ce02d85a36f18f3f40ab
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^24.9.0":
+  version: 24.9.0
+  resolution: "@jest/types@npm:24.9.0"
+  dependencies:
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^1.1.1
+    "@types/yargs": ^13.0.0
+  checksum: 603698f774cf22f9d16a0e0fac9e10e7db21052aebfa33db154c8a5940e0eb1fa9c079a8c91681041ad3aeee2adfa950608dd0c663130316ba034b8bca7b301c
   languageName: node
   linkType: hard
 
@@ -3152,12 +3223,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/assets-registry@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/assets-registry@npm:0.74.87"
+  checksum: 265a85038dd578546a6f9ce9e7f9c6b3e424051b9aac314e4804aea6370420be5c3207e6f672345c0e63fab49175d7b5bd1956a98b9fce080b81a054e43e4bb3
+  languageName: node
+  linkType: hard
+
 "@react-native/babel-plugin-codegen@npm:0.74.85":
   version: 0.74.85
   resolution: "@react-native/babel-plugin-codegen@npm:0.74.85"
   dependencies:
     "@react-native/codegen": 0.74.85
   checksum: d2bf5d94cc985405590cf80c95dafa20e7223edaa873709d2da72798b09d6fe0570941ef34656587691c5e52d0f4273dcb114450ebcc53f380f54ac68685c7e8
+  languageName: node
+  linkType: hard
+
+"@react-native/babel-plugin-codegen@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/babel-plugin-codegen@npm:0.74.87"
+  dependencies:
+    "@react-native/codegen": 0.74.87
+  checksum: f4d1d85deb0925d86a4763643f380afed37476733ef15e416f4022eab8a5aa51737406175c9701d19b9103f4359370a6a5d26f544f299660524fd2d8f5121b71
   languageName: node
   linkType: hard
 
@@ -3214,6 +3301,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/babel-preset@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/babel-preset@npm:0.74.87"
+  dependencies:
+    "@babel/core": ^7.20.0
+    "@babel/plugin-proposal-async-generator-functions": ^7.0.0
+    "@babel/plugin-proposal-class-properties": ^7.18.0
+    "@babel/plugin-proposal-export-default-from": ^7.0.0
+    "@babel/plugin-proposal-logical-assignment-operators": ^7.18.0
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.18.0
+    "@babel/plugin-proposal-numeric-separator": ^7.0.0
+    "@babel/plugin-proposal-object-rest-spread": ^7.20.0
+    "@babel/plugin-proposal-optional-catch-binding": ^7.0.0
+    "@babel/plugin-proposal-optional-chaining": ^7.20.0
+    "@babel/plugin-syntax-dynamic-import": ^7.8.0
+    "@babel/plugin-syntax-export-default-from": ^7.0.0
+    "@babel/plugin-syntax-flow": ^7.18.0
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.0.0
+    "@babel/plugin-syntax-optional-chaining": ^7.0.0
+    "@babel/plugin-transform-arrow-functions": ^7.0.0
+    "@babel/plugin-transform-async-to-generator": ^7.20.0
+    "@babel/plugin-transform-block-scoping": ^7.0.0
+    "@babel/plugin-transform-classes": ^7.0.0
+    "@babel/plugin-transform-computed-properties": ^7.0.0
+    "@babel/plugin-transform-destructuring": ^7.20.0
+    "@babel/plugin-transform-flow-strip-types": ^7.20.0
+    "@babel/plugin-transform-function-name": ^7.0.0
+    "@babel/plugin-transform-literals": ^7.0.0
+    "@babel/plugin-transform-modules-commonjs": ^7.0.0
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.0.0
+    "@babel/plugin-transform-parameters": ^7.0.0
+    "@babel/plugin-transform-private-methods": ^7.22.5
+    "@babel/plugin-transform-private-property-in-object": ^7.22.11
+    "@babel/plugin-transform-react-display-name": ^7.0.0
+    "@babel/plugin-transform-react-jsx": ^7.0.0
+    "@babel/plugin-transform-react-jsx-self": ^7.0.0
+    "@babel/plugin-transform-react-jsx-source": ^7.0.0
+    "@babel/plugin-transform-runtime": ^7.0.0
+    "@babel/plugin-transform-shorthand-properties": ^7.0.0
+    "@babel/plugin-transform-spread": ^7.0.0
+    "@babel/plugin-transform-sticky-regex": ^7.0.0
+    "@babel/plugin-transform-typescript": ^7.5.0
+    "@babel/plugin-transform-unicode-regex": ^7.0.0
+    "@babel/template": ^7.0.0
+    "@react-native/babel-plugin-codegen": 0.74.87
+    babel-plugin-transform-flow-enums: ^0.0.2
+    react-refresh: ^0.14.0
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 7a8f7c1bbba5cc50e6feeec2912b686b0d5d3257af11c15c6ebbadb501d5af7db29dca846ee79c4ad9d5e2737a4eb7e0a1a7df92c0bf173d7c82f9c3dcee7f6d
+  languageName: node
+  linkType: hard
+
 "@react-native/codegen@npm:0.74.85":
   version: 0.74.85
   resolution: "@react-native/codegen@npm:0.74.85"
@@ -3228,6 +3368,23 @@ __metadata:
   peerDependencies:
     "@babel/preset-env": ^7.1.6
   checksum: fb3e065774e5ad97c6af269407b543f286ea0d32d5ce62d3955e02c5514190700212aeb6aab0a3364636080d07643076f1caf771d4dfd594da5782fc2e7b87ae
+  languageName: node
+  linkType: hard
+
+"@react-native/codegen@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/codegen@npm:0.74.87"
+  dependencies:
+    "@babel/parser": ^7.20.0
+    glob: ^7.1.1
+    hermes-parser: 0.19.1
+    invariant: ^2.2.4
+    jscodeshift: ^0.14.0
+    mkdirp: ^0.5.1
+    nullthrows: ^1.1.1
+  peerDependencies:
+    "@babel/preset-env": ^7.1.6
+  checksum: 587b9eacebf3cc96055c11868ac3cf73be3c135cb15b9bb67d0c7b252ef7d46c13621bffd5cbeb5b1744cd9809e97f86d87cb7ab27d517b3aaefeef07fa70642
   languageName: node
   linkType: hard
 
@@ -3251,10 +3408,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/community-cli-plugin@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/community-cli-plugin@npm:0.74.87"
+  dependencies:
+    "@react-native-community/cli-server-api": 13.6.9
+    "@react-native-community/cli-tools": 13.6.9
+    "@react-native/dev-middleware": 0.74.87
+    "@react-native/metro-babel-transformer": 0.74.87
+    chalk: ^4.0.0
+    execa: ^5.1.1
+    metro: ^0.80.3
+    metro-config: ^0.80.3
+    metro-core: ^0.80.3
+    node-fetch: ^2.2.0
+    querystring: ^0.2.1
+    readline: ^1.3.0
+  checksum: 299735c5c62fae3cdd71470684cc9ed688cd146e134ed0d41d612b7a1b1356632d7fdd21034d86035117552f0e6db7e3fd1900a9df4633e7fe333b6338effb19
+  languageName: node
+  linkType: hard
+
 "@react-native/debugger-frontend@npm:0.74.85":
   version: 0.74.85
   resolution: "@react-native/debugger-frontend@npm:0.74.85"
   checksum: 0044555fa0024353b0d4d26f8a4b307796685820a5b12bdb3b971448347cf85787d947962451191196e6040fc916d5162e3f3593a312f31b9d58e74291fed147
+  languageName: node
+  linkType: hard
+
+"@react-native/debugger-frontend@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/debugger-frontend@npm:0.74.87"
+  checksum: dccd3d33774820ce9ca91910d13273c227ffb3b667fba5f3ec877c0d9b241e1cf16f8462b967ed52d1688826dd019d176a0425401b4d824568eda1faeec29f26
   languageName: node
   linkType: hard
 
@@ -3276,6 +3460,27 @@ __metadata:
     temp-dir: ^2.0.0
     ws: ^6.2.2
   checksum: 588bb3155ab9b26aa51dcdd0f7c2716f9a632a24f2f530772b43a9de1ccc712cc562ea9fe51d464c5f6263568929d875f2002a34f2acf60053de9daf374092cd
+  languageName: node
+  linkType: hard
+
+"@react-native/dev-middleware@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/dev-middleware@npm:0.74.87"
+  dependencies:
+    "@isaacs/ttlcache": ^1.4.1
+    "@react-native/debugger-frontend": 0.74.87
+    "@rnx-kit/chromium-edge-launcher": ^1.0.0
+    chrome-launcher: ^0.15.2
+    connect: ^3.6.5
+    debug: ^2.2.0
+    node-fetch: ^2.2.0
+    nullthrows: ^1.1.1
+    open: ^7.0.3
+    selfsigned: ^2.4.1
+    serve-static: ^1.13.1
+    temp-dir: ^2.0.0
+    ws: ^6.2.2
+  checksum: c78339f431d8206be0e3044435b994963bde0358c2210420fee939343d391cd117adaf3ee5895fbb3e7b829f31bef121602a71224e949941ee5e1c6a3677af49
   languageName: node
   linkType: hard
 
@@ -3317,10 +3522,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/gradle-plugin@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/gradle-plugin@npm:0.74.87"
+  checksum: b524e51b33a0ae4faf826928974390da164394b2f95fb203c903ff20ce2c66ef825bf8a0ae228c37b9c5e417e7af66070e97ea6590d3ce3a933599cde8f8ba7e
+  languageName: node
+  linkType: hard
+
 "@react-native/js-polyfills@npm:0.74.85":
   version: 0.74.85
   resolution: "@react-native/js-polyfills@npm:0.74.85"
   checksum: 9fd657949141a0ab155f533345cf5c839133db0421968dd5085836d82112c02a8beabdb4ab332c01413c3fe6bdc5ed33c0c2e88e9ed5b860b056c29f9910a7a1
+  languageName: node
+  linkType: hard
+
+"@react-native/js-polyfills@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/js-polyfills@npm:0.74.87"
+  checksum: 268df78b62d22af2ad3e70e107ba0dd5d3c242a5fb11388dd9967c8bb46ce89433fbffd115c3752d31b3bde80616d1f6386edda4538983ddd74eb0df7c72344e
   languageName: node
   linkType: hard
 
@@ -3338,10 +3557,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/metro-babel-transformer@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/metro-babel-transformer@npm:0.74.87"
+  dependencies:
+    "@babel/core": ^7.20.0
+    "@react-native/babel-preset": 0.74.87
+    hermes-parser: 0.19.1
+    nullthrows: ^1.1.1
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: c665e7652aa086ed04efa03cfcaa22a405f2c885e844b23b194c5860f7ec616a59c6ac189dc024c8117a684b3d730c383d51f2a28f360277ab446a0f2ff0210c
+  languageName: node
+  linkType: hard
+
 "@react-native/normalize-colors@npm:0.74.85, @react-native/normalize-colors@npm:^0.74.1":
   version: 0.74.85
   resolution: "@react-native/normalize-colors@npm:0.74.85"
   checksum: d2aef06be265c27ec89e1bec8f3a6869a62300479fbafdabd5e06323cf22a892189d42f9f613cc48c48f97351634c9ce98b07e565d9344714bb2627e5aae4c60
+  languageName: node
+  linkType: hard
+
+"@react-native/normalize-colors@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/normalize-colors@npm:0.74.87"
+  checksum: 903f9cd8a0fdcb26f4f621b260b9f48e703ca183ac4ee363b6dea4f424e23a254adebe36ce3d560e6e909f58b1c568bafe596e5858fadf51b5be080f401446c7
   languageName: node
   linkType: hard
 
@@ -3359,6 +3599,23 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 20e67922883fd862a6b8274d70707f70cf8294bed75a582f267c38cf196088d27eeacbb062d86294068cb9ed9cda748c113f390cac21424058404f60196a1b4c
+  languageName: node
+  linkType: hard
+
+"@react-native/virtualized-lists@npm:0.74.87":
+  version: 0.74.87
+  resolution: "@react-native/virtualized-lists@npm:0.74.87"
+  dependencies:
+    invariant: ^2.2.4
+    nullthrows: ^1.1.1
+  peerDependencies:
+    "@types/react": ^18.2.6
+    react: "*"
+    react-native: "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 417e9b4044ef48943914ff729995d908cf0df7f337403be80d126fc7d5542df1cc6d40503504b60a65f411002d138bb7e65fd8b10b931df640297d6daa8de263
   languageName: node
   linkType: hard
 
@@ -3613,6 +3870,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/istanbul-reports@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@types/istanbul-reports@npm:1.1.2"
+  dependencies:
+    "@types/istanbul-lib-coverage": "*"
+    "@types/istanbul-lib-report": "*"
+  checksum: 00866e815d1e68d0a590d691506937b79d8d65ad8eab5ed34dbfee66136c7c0f4ea65327d32046d5fe469f22abea2b294987591dc66365ebc3991f7e413b2d78
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-reports@npm:^3.0.0":
   version: 3.0.4
   resolution: "@types/istanbul-reports@npm:3.0.4"
@@ -3747,6 +4014,15 @@ __metadata:
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
   checksum: ef236c27f9432983e91432d974243e6c4cdae227cb673740320eff32d04d853eed59c92ca6f1142a335cfdc0e17cccafa62e95886a8154ca8891cc2dec4ee6fc
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^13.0.0":
+  version: 13.0.12
+  resolution: "@types/yargs@npm:13.0.12"
+  dependencies:
+    "@types/yargs-parser": "*"
+  checksum: 4eb34d8c071892299646e5a3fb02a643f5a5ea8da8f4d1817001882ebbcfa4fbda235b8978732f8eb55fa16433296e2087907fe69678a69125f0dca627a91426
   languageName: node
   linkType: hard
 
@@ -4164,7 +4440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^4.1.0":
+"ansi-regex@npm:^4.0.0, ansi-regex@npm:^4.1.0":
   version: 4.1.1
   resolution: "ansi-regex@npm:4.1.1"
   checksum: b1a6ee44cb6ecdabaa770b2ed500542714d4395d71c7e5c25baa631f680fb2ad322eb9ba697548d498a6fd366949fc8b5bfcf48d49a32803611f648005b01888
@@ -4561,10 +4837,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-react-compiler@npm:^0.0.0-experimental-592953e-20240517":
-  version: 0.0.0
-  resolution: "babel-plugin-react-compiler@npm:0.0.0"
-  checksum: 6413005e947f9ee089359e354ab279956a6c7d979c397b3fcc311fe9d6599a83d4343f2de5cb6aebf38b1ebc1dfdc05b5fe1ea37b84c4ff891b31d6d1d59b899
+"babel-plugin-react-compiler@npm:0.0.0-experimental-592953e-20240517":
+  version: 0.0.0-experimental-592953e-20240517
+  resolution: "babel-plugin-react-compiler@npm:0.0.0-experimental-592953e-20240517"
+  dependencies:
+    "@babel/generator": 7.2.0
+    "@babel/types": ^7.19.0
+    chalk: 4
+    invariant: ^2.2.4
+    pretty-format: ^24
+    zod: ^3.22.4
+    zod-validation-error: ^2.1.0
+  checksum: f21ff9fc0139de33f94482d600542557d34b3ecb5e70e7f765b4b912a3a15d922cd3c5bcd46ffba4a7c0e6a075d6b93629105c2b8d19d8b6ce61ca8000bde653
   languageName: node
   linkType: hard
 
@@ -4606,9 +4890,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-expo@npm:~11.0.12":
-  version: 11.0.12
-  resolution: "babel-preset-expo@npm:11.0.12"
+"babel-preset-expo@npm:~11.0.15":
+  version: 11.0.15
+  resolution: "babel-preset-expo@npm:11.0.15"
   dependencies:
     "@babel/plugin-proposal-decorators": ^7.12.9
     "@babel/plugin-transform-export-namespace-from": ^7.22.11
@@ -4616,11 +4900,11 @@ __metadata:
     "@babel/plugin-transform-parameters": ^7.22.15
     "@babel/preset-react": ^7.22.15
     "@babel/preset-typescript": ^7.23.0
-    "@react-native/babel-preset": 0.74.85
-    babel-plugin-react-compiler: ^0.0.0-experimental-592953e-20240517
+    "@react-native/babel-preset": 0.74.87
+    babel-plugin-react-compiler: 0.0.0-experimental-592953e-20240517
     babel-plugin-react-native-web: ~0.19.10
     react-refresh: ^0.14.2
-  checksum: f0791ca13d1b7361e015f11e545d2b8b591b0a73653d509fa832e0f2b01dac5f20745454a07bca32fc3b95f4e47aa3f50f016ef70ffe4a34d2e7006cc21491e8
+  checksum: 84e36d06e0ff4fda65d4f5fbed99e29030677e847de0f81fe93ba17772b7887b292d82ec5d77be8c81c8af6a5c46c4f07016a05f0319e949c3b4e48e09cb26e2
   languageName: node
   linkType: hard
 
@@ -5085,6 +5369,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:4, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+  languageName: node
+  linkType: hard
+
 "chalk@npm:5.2.0":
   version: 5.2.0
   resolution: "chalk@npm:5.2.0"
@@ -5100,16 +5394,6 @@ __metadata:
     escape-string-regexp: ^1.0.5
     supports-color: ^5.3.0
   checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
   languageName: node
   linkType: hard
 
@@ -6987,14 +7271,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-font@npm:~12.0.9":
-  version: 12.0.9
-  resolution: "expo-font@npm:12.0.9"
+"expo-font@npm:~12.0.10":
+  version: 12.0.10
+  resolution: "expo-font@npm:12.0.10"
   dependencies:
     fontfaceobserver: ^2.1.0
   peerDependencies:
     expo: "*"
-  checksum: adad225ed6002d5d527808b8f463bc59a1a1626fb2ff34918dcbd2172757977c056101f737ed9523f6d55e0aa88a64988002eb9b6d22f379d5956883f7451379
+  checksum: c8fdc046158d4c2d71d81fcd9ba115bc0e142bc0d637ae9b5fea04cd816c62c051f63e44685530109106565d29feca2035ef6123c56cf9c951d0a2775a8cd9a7
   languageName: node
   linkType: hard
 
@@ -7007,27 +7291,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-modules-autolinking@npm:1.11.1":
-  version: 1.11.1
-  resolution: "expo-modules-autolinking@npm:1.11.1"
+"expo-modules-autolinking@npm:1.11.3":
+  version: 1.11.3
+  resolution: "expo-modules-autolinking@npm:1.11.3"
   dependencies:
     chalk: ^4.1.0
     commander: ^7.2.0
     fast-glob: ^3.2.5
     find-up: ^5.0.0
     fs-extra: ^9.1.0
+    require-from-string: ^2.0.2
+    resolve-from: ^5.0.0
   bin:
     expo-modules-autolinking: bin/expo-modules-autolinking.js
-  checksum: 45936fe2d4a38b44477875f3eafd915f62035ff6e6abde1d36c3dc4fac087f284c5458b5edc3c235c7a9d3b525efd5886fe43432f565da135c87a5bf1b4e07fd
+  checksum: 940c2d35d41515f9dff33fec145db763923bdd8a1a782cd7fb04b216f7c01acd7dbd9d5792941f8dd85ae0bb65d97ae89dfe3cecbdb632964e3376616e76d7c8
   languageName: node
   linkType: hard
 
-"expo-modules-core@npm:1.12.19":
-  version: 1.12.19
-  resolution: "expo-modules-core@npm:1.12.19"
+"expo-modules-core@npm:1.12.26":
+  version: 1.12.26
+  resolution: "expo-modules-core@npm:1.12.26"
   dependencies:
     invariant: ^2.2.4
-  checksum: f634bafecc9cd3fa508ea5c6ae7b1dd19ee23471636a92f90c8cec009dabb60ed687811414112379f19033487e0d0990f88007d481cf9da178dcb5ac284c25e3
+  checksum: 9fe31a57ccf47205aff939f185c402860f4e3e36d93ffddb06743e086066115edf52f7e3b2253ed4690ec8daa7c008165c338aaa3806f6e4447722d661823e6b
   languageName: node
   linkType: hard
 
@@ -7038,28 +7324,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo@npm:~51.0.22":
-  version: 51.0.22
-  resolution: "expo@npm:51.0.22"
+"expo@npm:~51.0.39":
+  version: 51.0.39
+  resolution: "expo@npm:51.0.39"
   dependencies:
     "@babel/runtime": ^7.20.0
-    "@expo/cli": 0.18.25
-    "@expo/config": 9.0.3
-    "@expo/config-plugins": 8.0.8
-    "@expo/metro-config": 0.18.9
-    "@expo/vector-icons": ^14.0.0
-    babel-preset-expo: ~11.0.12
+    "@expo/cli": 0.18.31
+    "@expo/config": 9.0.4
+    "@expo/config-plugins": 8.0.11
+    "@expo/metro-config": 0.18.11
+    "@expo/vector-icons": ^14.0.3
+    babel-preset-expo: ~11.0.15
     expo-asset: ~10.0.10
     expo-file-system: ~17.0.1
-    expo-font: ~12.0.9
+    expo-font: ~12.0.10
     expo-keep-awake: ~13.0.2
-    expo-modules-autolinking: 1.11.1
-    expo-modules-core: 1.12.19
+    expo-modules-autolinking: 1.11.3
+    expo-modules-core: 1.12.26
     fbemitter: ^3.0.0
     whatwg-url-without-unicode: 8.0.0-3
   bin:
     expo: bin/cli
-  checksum: 99274c8da23fa6c81825b4bdac6a264700cdf0a17cc101ed31f3700dbc78e75c6ec0e41a724b2c591269e41163f9cf52745b83e54ce831342192c0cfdd5144b6
+  checksum: ad95861fee0e0734a539f6c7656a2254eecf1b0039e50737f35d97c84770d73274b75a7f5c75908fe5fe6b498ae9c98f5531e3f13b7e621aeccc00b201d0b600
   languageName: node
   linkType: hard
 
@@ -10082,7 +10368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.13, lodash@npm:^4.17.21":
+"lodash@npm:4.17.21, lodash@npm:^4.17.10, lodash@npm:^4.17.13, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -11909,6 +12195,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^24":
+  version: 24.9.0
+  resolution: "pretty-format@npm:24.9.0"
+  dependencies:
+    "@jest/types": ^24.9.0
+    ansi-regex: ^4.0.0
+    ansi-styles: ^3.2.0
+    react-is: ^16.8.4
+  checksum: ba9291c8dafd50d2fea1fbad5d2863a6f94e0c8835cce9778ec03bc11bb0f52b9ed0e4ee56aaa331d022ccae2fe52b92f73465a0af58fd0edb59deb6391c6847
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^26.5.2, pretty-format@npm:^26.6.2":
   version: 26.6.2
   resolution: "pretty-format@npm:26.6.2"
@@ -12175,7 +12473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.8.4":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -12350,6 +12648,59 @@ __metadata:
   bin:
     react-native: cli.js
   checksum: bfa1c4a9823149a0895c7cd9db2d7ebb93fe5497cad2fc44e236479fc3e3fb690b3fda86aee4cd3f6d767ed3e62fb3f0ab9bfbd56e29a46d3f2f21040129783c
+  languageName: node
+  linkType: hard
+
+"react-native@npm:0.74.5":
+  version: 0.74.5
+  resolution: "react-native@npm:0.74.5"
+  dependencies:
+    "@jest/create-cache-key-function": ^29.6.3
+    "@react-native-community/cli": 13.6.9
+    "@react-native-community/cli-platform-android": 13.6.9
+    "@react-native-community/cli-platform-ios": 13.6.9
+    "@react-native/assets-registry": 0.74.87
+    "@react-native/codegen": 0.74.87
+    "@react-native/community-cli-plugin": 0.74.87
+    "@react-native/gradle-plugin": 0.74.87
+    "@react-native/js-polyfills": 0.74.87
+    "@react-native/normalize-colors": 0.74.87
+    "@react-native/virtualized-lists": 0.74.87
+    abort-controller: ^3.0.0
+    anser: ^1.4.9
+    ansi-regex: ^5.0.0
+    base64-js: ^1.5.1
+    chalk: ^4.0.0
+    event-target-shim: ^5.0.1
+    flow-enums-runtime: ^0.0.6
+    invariant: ^2.2.4
+    jest-environment-node: ^29.6.3
+    jsc-android: ^250231.0.0
+    memoize-one: ^5.0.0
+    metro-runtime: ^0.80.3
+    metro-source-map: ^0.80.3
+    mkdirp: ^0.5.1
+    nullthrows: ^1.1.1
+    pretty-format: ^26.5.2
+    promise: ^8.3.0
+    react-devtools-core: ^5.0.0
+    react-refresh: ^0.14.0
+    react-shallow-renderer: ^16.15.0
+    regenerator-runtime: ^0.13.2
+    scheduler: 0.24.0-canary-efb381bbf-20230505
+    stacktrace-parser: ^0.1.10
+    whatwg-fetch: ^3.0.0
+    ws: ^6.2.2
+    yargs: ^17.6.2
+  peerDependencies:
+    "@types/react": ^18.2.6
+    react: 18.2.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  bin:
+    react-native: cli.js
+  checksum: 3ac8df993a8ca1e2598049dfcdd10ef5708292be37137c7c39884f36044b83b2cbb7b1354059b48551b3570135ea8570c914e64a882a5d51e641d33c40f759bd
   languageName: node
   linkType: hard
 
@@ -13346,7 +13697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.5.6":
+"source-map@npm:^0.5.0, source-map@npm:^0.5.6":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
   checksum: 5dc2043b93d2f194142c7f38f74a24670cd7a0063acdaf4bf01d2964b402257ae843c2a8fa822ad5b71013b5fcafa55af7421383da919752f22ff488bc553f4d
@@ -14037,6 +14388,13 @@ __metadata:
   version: 4.1.1
   resolution: "trim-newlines@npm:4.1.1"
   checksum: 5b09f8e329e8f33c1111ef26906332ba7ba7248cde3e26fc054bb3d69f2858bf5feedca9559c572ff91f33e52977c28e0d41c387df6a02a633cbb8c2d8238627
+  languageName: node
+  linkType: hard
+
+"trim-right@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "trim-right@npm:1.0.1"
+  checksum: 9120af534e006a7424a4f9358710e6e707887b6ccf7ea69e50d6ac6464db1fe22268400def01752f09769025d480395159778153fb98d4a2f6f40d4cf5d4f3b6
   languageName: node
   linkType: hard
 
@@ -15056,5 +15414,21 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zod-validation-error@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "zod-validation-error@npm:2.1.0"
+  peerDependencies:
+    zod: ^3.18.0
+  checksum: 2331cc8d876c2df0b720b648249447b65d6b85ad0b6e60dd6515170570e6ffbe7a9adb844d44035c07d59c871048d9c45a8c429849bedeb8cbcdfa5f90101402
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4":
+  version: 3.23.8
+  resolution: "zod@npm:3.23.8"
+  checksum: 15949ff82118f59c893dacd9d3c766d02b6fa2e71cf474d5aa888570c469dbf5446ac5ad562bb035bf7ac9650da94f290655c194f4a6de3e766f43febd432c5c
   languageName: node
   linkType: hard


### PR DESCRIPTION
Implements feature-parity to markdown styles at `blinks`( https://github.com/dialectlabs/blinks/pull/37), with an exception of task lists, which are currently omitted and rendered as is.